### PR TITLE
Fix OSX mouse crash

### DIFF
--- a/mouse_mac.cpp
+++ b/mouse_mac.cpp
@@ -28,6 +28,7 @@ bool mouseClass::init()
 bool mouseClass::move(int dx, int dy)
 {
   //Gotcha - when a key is pressed, while moving, emit not mouse moved, but mouse dragged event
+  data->mutex.lock();
   CGEventType event;
   CGEventRef ev_ref;
   CGPoint pos;


### PR DESCRIPTION
The mutex wasn't locked before being unlocked, which caused mickey to crash when it tried to move the mouse on OSX.

Now mickey works great on OSX except for one outstanding bug: putting the TrackIR 5 into an error state when mickey is quit gracefully, but not when the process is forcefully killed. But that isn't a big issue since unplugging and replugging it works.

@uglyDwarf 
