### PR TITLE
Add velocity-based control mode

### DIFF
--- a/mickey.h
+++ b/mickey.h
@@ -211,9 +211,9 @@ class MickeyGUI : public QWidget
     {curvature = val; emit axisChanged(); ui.ApplyButton->setEnabled(true);};
   void on_SmoothingSlider_valueChanged(int val)
     {smoothing = val; emit axisChanged(); ui.ApplyButton->setEnabled(true);};
-  void on_RelativeCB_clicked(bool checked){mickey->setMode(Mickey::Relative);changed = true;};
-  void on_VelocityCB_clicked(bool checked){mickey->setMode(Mickey::Velocity);changed = true;};
-  void on_AbsoluteCB_clicked(bool checked){mickey->setMode(Mickey::Absolute);changed = true;};
+  void on_RelativeCB_clicked(bool checked){(void) checked; mickey->setMode(Mickey::Relative);changed = true;};
+  void on_VelocityCB_clicked(bool checked){(void) checked; mickey->setMode(Mickey::Velocity);changed = true;};
+  void on_AbsoluteCB_clicked(bool checked){(void) checked; mickey->setMode(Mickey::Absolute);changed = true;};
   void on_StepOnly_stateChanged(int state);
   void on_ApplyButton_pressed()
     {changed = true; ui.ApplyButton->setEnabled(false); mickey->applySettings();};

--- a/mickey.h
+++ b/mickey.h
@@ -109,12 +109,14 @@ class Mickey : public QObject
 {
  Q_OBJECT
  public: 
+  enum Mode { Relative, Absolute, Velocity };
+
   Mickey();
   ~Mickey();
   state_t getState() const{return state;};
   void applySettings();
-  void setRelative(bool rel){relative = rel;};
-  bool getRelative(){return relative;};
+  void setMode(Mickey::Mode m){mode = m;};
+  Mickey::Mode getMode(){return mode;};
   void recenter();
   void calibrate();
  private:
@@ -133,7 +135,7 @@ class Mickey : public QObject
   QDesktopWidget *dw;
   QRect screenBBox;
   QPoint screenCenter;
-  bool relative;
+  Mickey::Mode mode;
  private slots:
   void hotKey_activated(int id, bool pressed);
   void updateTimer_activated();
@@ -209,8 +211,9 @@ class MickeyGUI : public QWidget
     {curvature = val; emit axisChanged(); ui.ApplyButton->setEnabled(true);};
   void on_SmoothingSlider_valueChanged(int val)
     {smoothing = val; emit axisChanged(); ui.ApplyButton->setEnabled(true);};
-  void on_RelativeCB_clicked(bool checked){mickey->setRelative(checked);changed = true;};
-  void on_AbsoluteCB_clicked(bool checked){mickey->setRelative(!checked);changed = true;};
+  void on_RelativeCB_clicked(bool checked){mickey->setMode(Mickey::Relative);changed = true;};
+  void on_VelocityCB_clicked(bool checked){mickey->setMode(Mickey::Velocity);changed = true;};
+  void on_AbsoluteCB_clicked(bool checked){mickey->setMode(Mickey::Absolute);changed = true;};
   void on_StepOnly_stateChanged(int state);
   void on_ApplyButton_pressed()
     {changed = true; ui.ApplyButton->setEnabled(false); mickey->applySettings();};

--- a/mickey.pro
+++ b/mickey.pro
@@ -54,12 +54,13 @@ unix:!macx {
 }
 
 macx {
-  SOURCES += mouse_mac.cpp keyb_mac.cpp
+  SOURCES += keyb_mac.cpp
+  OBJECTIVE_SOURCES += mouse_mac.mm
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.6
   QMAKE_MAC_SDK=macosx
   #QMAKE_MAC_SDK=/Developer/SDKs/MacOSX10.6.sdk
   CONFIG+=x86_64
-  LIBS += -lm -framework ApplicationServices
+  LIBS += -lm -framework ApplicationServices -framework AppKit -framework Foundation
   help.path += mickey.app/Contents/Resources/linuxtrack/help/mickey
   help.files += help/*
   INSTALLS += help

--- a/mickey.pro
+++ b/mickey.pro
@@ -57,7 +57,7 @@ macx {
   SOURCES += keyb_mac.cpp
   OBJECTIVE_SOURCES += mouse_mac.mm
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.6
-  QMAKE_MAC_SDK=macosx
+  QMAKE_MAC_SDK = macosx10.11
   #QMAKE_MAC_SDK=/Developer/SDKs/MacOSX10.6.sdk
   CONFIG+=x86_64
   LIBS += -lm -framework ApplicationServices -framework AppKit -framework Foundation

--- a/mickey.ui
+++ b/mickey.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>569</width>
-    <height>415</height>
+    <width>801</width>
+    <height>587</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -54,6 +54,13 @@
             <property name="bottomMargin">
              <number>2</number>
             </property>
+            <item>
+             <widget class="QRadioButton" name="VelocityCB">
+              <property name="text">
+               <string>Velocity</string>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="QRadioButton" name="RelativeCB">
               <property name="text">
@@ -277,7 +284,16 @@
             <enum>QFrame::Raised</enum>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_8">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>2</number>
+            </property>
+            <property name="topMargin">
+             <number>2</number>
+            </property>
+            <property name="rightMargin">
+             <number>2</number>
+            </property>
+            <property name="bottomMargin">
              <number>2</number>
             </property>
             <item>
@@ -502,7 +518,16 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>1</number>
+      </property>
+      <property name="topMargin">
+       <number>1</number>
+      </property>
+      <property name="rightMargin">
+       <number>1</number>
+      </property>
+      <property name="bottomMargin">
        <number>1</number>
       </property>
       <item>
@@ -682,6 +707,70 @@
     <hint type="destinationlabel">
      <x>92</x>
      <y>193</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>VelocityCB</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>SensSlider</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>103</x>
+     <y>74</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>251</x>
+     <y>115</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>VelocityCB</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>CurveSlider</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>103</x>
+     <y>74</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>251</x>
+     <y>183</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>VelocityCB</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>DZSlider</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>103</x>
+     <y>74</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>251</x>
+     <y>149</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>VelocityCB</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>StepOnly</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>103</x>
+     <y>74</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>254</x>
+     <y>248</y>
     </hint>
    </hints>
   </connection>

--- a/mouse_mac.cpp
+++ b/mouse_mac.cpp
@@ -54,6 +54,7 @@ bool mouseClass::move(int dx, int dy)
 
 bool mouseClass::click(buttons_t buttons, struct timeval ts)
 {
+  (void) ts;
   data->mutex.lock();
   buttons_t changed = (buttons_t)(buttons ^ data->pressed);
   CGEventType event;

--- a/mouse_mac.cpp
+++ b/mouse_mac.cpp
@@ -28,6 +28,7 @@ bool mouseClass::init()
 bool mouseClass::move(int dx, int dy)
 {
   //Gotcha - when a key is pressed, while moving, emit not mouse moved, but mouse dragged event
+  data->mutex.lock();
   CGEventType event;
   CGEventRef ev_ref;
   CGPoint pos;

--- a/mouse_mac.mm
+++ b/mouse_mac.mm
@@ -5,12 +5,14 @@
 #include <QDesktopWidget>
 #include <ApplicationServices/ApplicationServices.h>
 
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
 struct mouseLocalData{
   mouseLocalData():pressed((buttons_t)0){}
   buttons_t pressed;
   QMutex mutex;
 };
-
 
 mouseClass::mouseClass(){
   data = new mouseLocalData();
@@ -36,13 +38,15 @@ bool mouseClass::move(int dx, int dy)
   pos.x = currentPos.x() + dx;
   pos.y = currentPos.y() + dy;
   
-  if(data->pressed == 0){
-    event = kCGEventMouseMoved;
-  }else if(data->pressed & LEFT_BUTTON){
+  int pressed = [NSEvent pressedMouseButtons];
+  if(pressed & LEFT_BUTTON){
     event = kCGEventLeftMouseDragged;
-  }else if(data->pressed & RIGHT_BUTTON){
+  } else if(pressed & RIGHT_BUTTON){
     event = kCGEventRightMouseDragged;
+  } else {
+    event = kCGEventMouseMoved;
   }
+
   ev_ref = CGEventCreateMouseEvent(NULL, event, pos, 0);
   CGEventPost(kCGHIDEventTap, ev_ref);
   CFRelease(ev_ref);

--- a/transform.cpp
+++ b/transform.cpp
@@ -237,10 +237,11 @@ void MickeyTransform::update(float valX, float valY, Mickey::Mode mode, int elap
       //std::cout<<"valX: "<<-valX<<"=> "<<x<<"   Limit: "<<maxValX<<"   CurrentLimit:"<<currMaxValX<<std::endl;
     }else{
       axis.step(norm(-valX/maxValX), norm(-valY/maxValY), elapsed, accX, accY);
-      x = accX;
-      y = accY;
-      accX = 0;
-      accY = 0;
+      // buffer up small changes until they reach integer values
+      x = floor(accX);
+      y = floor(accY);
+      accX -= x;
+      accY -= y;
     }
   }else{
     if(valX > maxValX){

--- a/transform.h
+++ b/transform.h
@@ -73,10 +73,10 @@ class MickeyTransform : public QObject
  private:
   float accX, accY;
   bool calibrating;
+  MickeysAxis axis;
   float prevValX, prevValY;
   float maxValX, minValX, maxValY, minValY, prevMaxValX, prevMaxValY;
   float currMaxValX, currMaxValY;
-  MickeysAxis axis;
 };
 
 

--- a/transform.h
+++ b/transform.h
@@ -63,7 +63,7 @@ class MickeyTransform : public QObject
  public:
   MickeyTransform();
   ~MickeyTransform();
-  void update(float valX, float valY, bool relative, int elapsed, float &x, float &y);
+  void update(float valX, float valY, Mickey::Mode mode, int elapsed, float &x, float &y);
   void startCalibration();
   void finishCalibration();
   void cancelCalibration();
@@ -73,6 +73,7 @@ class MickeyTransform : public QObject
  private:
   float accX, accY;
   bool calibrating;
+  float prevValX, prevValY;
   float maxValX, minValX, maxValY, minValY, prevMaxValX, prevMaxValY;
   float currMaxValX, currMaxValY;
   MickeysAxis axis;


### PR DESCRIPTION
Fixes #4. Adds another radio button for a velocity based control mode. Most of the code in this PR is small changes to refactor the assumption that there are only two modes. The actual velocity control code is in `transform.cpp`'s `update` method.

@uglyDwarf for review. Since this is a bigger change feel free to suggest better ways to do things and I can tweak this PR.

This PR is based on #3 because that hasn't been merged yet and I needed it to test this.

![screen shot 2015-08-16 at 5 19 29 pm](https://cloud.githubusercontent.com/assets/887610/9295439/f0576bae-443b-11e5-99a0-88b5175910a5.png)
