### PR TITLE
Disable App Nap and WebView to fix macOS/OSX

### DIFF
--- a/help_view.cpp
+++ b/help_view.cpp
@@ -50,7 +50,7 @@ void HelpViewer::ChangeHelpPage(QString name)
 {
   QString tmp = QString::fromUtf8("file://") + getDataPath(QString::fromUtf8("/help/") + 
                   QString::fromUtf8(HELP_BASE) + name);
-  viewer->load(QUrl(tmp));
+//  viewer->load(QUrl(tmp));
 }
 
 void HelpViewer::CloseWindow()
@@ -80,20 +80,20 @@ HelpViewer::HelpViewer(QWidget *parent) : QWidget(parent), contents(NULL), layou
 {
   ui.setupUi(this);
   setWindowTitle(QString::fromUtf8("Help viewer"));
-  viewer = new QWebView(this);
+//  viewer = new QWebView(this);
   contents = new QListWidget(this);
   ReadContents();
   layout = new QHBoxLayout();
   splitter = new QSplitter();
   layout->addWidget(splitter);
   splitter->addWidget(contents);
-  splitter->addWidget(viewer);
+//  splitter->addWidget(viewer);
   ui.verticalLayout->insertLayout(0, layout);
   QObject::connect(contents, SIGNAL(currentTextChanged(const QString &)), 
                    this, SLOT(currentTextChanged(const QString &)));
   
-  QObject::connect(viewer, SIGNAL(linkClicked(const QUrl&)), this, SLOT(followLink(const QUrl&)));
-  viewer->page()->setLinkDelegationPolicy(QWebPage::DelegateAllLinks);
+//  QObject::connect(viewer, SIGNAL(linkClicked(const QUrl&)), this, SLOT(followLink(const QUrl&)));
+//  viewer->page()->setLinkDelegationPolicy(QWebPage::DelegateAllLinks);
 }
 
 bool HelpViewer::ReadContents()
@@ -141,7 +141,7 @@ void HelpViewer::followLink(const QUrl &url)
   if(QString::fromUtf8("http").compare(url.scheme(), Qt::CaseInsensitive) == 0){
     QDesktopServices::openUrl(url);
   }else{
-    viewer->load(url);
+//    viewer->load(url);
   }
 }
 
@@ -149,9 +149,9 @@ HelpViewer::~HelpViewer()
 {
   ui.verticalLayout->removeItem(layout);
   layout->removeWidget(contents);
-  layout->removeWidget(viewer);
+//  layout->removeWidget(viewer);
   delete(layout);
   delete(contents);
-  delete(viewer);
+//  delete(viewer);
 }
 

--- a/help_view.h
+++ b/help_view.h
@@ -1,7 +1,7 @@
 #include <QWidget>
 #include <QFile>
 #include <QTextStream>
-#include <QWebView>
+//#include <QWebView>
 #include <QSplitter>
 #include <QListWidget>
 #include "ui_logview.h"
@@ -32,7 +32,7 @@ class HelpViewer : public QWidget{
   void addPage(QString name, QString page);
   bool ReadContents();
   Ui::LogViewerForm ui;
-  QWebView *viewer;
+//  QWebView *viewer;
   QListWidget *contents;
   QHBoxLayout *layout;
   QSplitter *splitter;

--- a/mickey.pro
+++ b/mickey.pro
@@ -6,9 +6,9 @@ CONFIG += qt debug warn_on precompile_header
 TEMPLATE = app
 TARGET = mickey
 DEPENDPATH += .
-QT += webkit
+# QT += webkit
 contains(QT_VERSION, ^5.*){
-       QT += webkitwidgets widgets
+       QT += widgets
        DEFINES += QT5_OVERRIDES
 }
 

--- a/mouse_mac.mm
+++ b/mouse_mac.mm
@@ -33,6 +33,11 @@ struct mouseLocalData{
 };
 
 mouseClass::mouseClass(){
+  // Without this line, App Nap will eventually activate, stopping tracking.
+  // Even worse, it seems to reactivate on click events, but without data, moving the mouse to (0,0)
+  // This doesn't keep track of the activity, because we never need to disable it.
+  [[NSProcessInfo processInfo] beginActivityWithOptions: NSActivityUserInitiated reason:@"Head Tracking"];
+
   data = new mouseLocalData();
 }
   


### PR DESCRIPTION
This PR does two things:

- Disable the WebView in the help page, new versions of Qt don't have the web view anymore.
- Disable AppNap, so that tracking doesn't freeze a minute after starting.

This is not a proper fix since it just removes the help view. I don't expect this to be merged yet, I'm just leaving this PR here for other people to find. But I don't think I have time to do the right thing and port it to WebEngine, since I seem to have not installed the WebEngine component in my Qt install.

It shouldn't be too hard to port it to WebEngine though if anyone else wants to try: http://doc.qt.io/qt-5/qtwebenginewidgets-qtwebkitportingguide.html

cc @uglyDwarf 